### PR TITLE
Add a Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR adds a Dependabot config that will autoupdate GitHub action versions.

For example, when this merges, you can expect Dependabot to open PRs to update `actions/checkout@v2` to v3, and to update `actions/setup-python@v2` to v4. This will resolve deprecation warnings that are currently getting emitted when CI runs [[recent example run](https://github.com/cvxgrp/dsp/actions/runs/5163238107)].

Using Dependabot will address aging action versions automatically, rather than dealing with them manually over time. This will reduce maintenance burden.

See you at SciPy 2023!