### PR TITLE
Use tox to manage the test suite

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
-source = dsp
+parallel = true
+source = dsp, tests
 relative_files = True
 
 [report]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,17 +33,18 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: |
+            3.11
+            3.10
+            3.9
+            3.8
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # For sonar
       - name: Install dependencies
-        run: |
-          pip install .
-          pip install pytest pytest-cov pandas
+        run: pip install tox
       - name: Run tests
-        run: |
-          pytest --cov=dsp --cov-report xml:coverage.xml
+        run: tox
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = True
 include_package_data = True
 
 [options.extras_require]
-dev = pytest
+dev = tox
 
 [options.package_data]
 * = README.md

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,57 @@
+[tox]
+min_version = 4.3.5
+
+envlist =
+    coverage_erase
+    py{3.11, 3.10, 3.9, 3.8}
+    coverage_report
+    docs
+
+skip_missing_interpreters = True
+isolated_build = True
+
+
+[testenv]
+description = Test
+package = wheel
+wheel_build_env = build_wheel
+
+depends =
+    py{3.11, 3.10, 3.9, 3.8}: coverage_erase
+deps =
+    coverage
+    pandas
+    pytest
+commands =
+    coverage run -m pytest
+
+
+[testenv:docs]
+description = Test documentation builds
+skipsdist = true
+skip_install = true
+deps =
+    sphinx
+    cvxpy
+commands = sphinx-build -aEnqb html docs/ build/docs
+
+
+[testenv:coverage_erase]
+description = Erase coverage files
+skipsdist = true
+skip_install = true
+deps = coverage
+commands = coverage erase
+
+
+[testenv:coverage_report]
+description = Report coverage
+depends =
+    py{3.11, 3.10, 3.9, 3.8}
+skipsdist = true
+skip_install = true
+deps = coverage
+commands_pre =
+    coverage combine
+    coverage html --fail-under=0
+commands = coverage report


### PR DESCRIPTION
This PR introduces tox to manage the test suite. This includes the following changes:

* The test suite is now run on Python 3.8 through Python 3.11 automatically.
* Coverage reports include runs across all Python versions, not just Python 3.8.
* The coverage report include coverage of the `tests/` directory.
* The documentation is built as a part of the test suite.
* pandas is now recognized as a test dependency (previously the test suite would fail when pandas was not manually installed).
* CI now runs the test suite across all Python versions, including building the docs.

To run the test suite locally, simply install tox (`pip install tox`) and run `tox`. To run the tests in parallel, run `tox parallel` or `tox p`.