### PR TITLE
cvxpy and and scipy compatibility fixes

### DIFF
--- a/dsp/cone_transforms.py
+++ b/dsp/cone_transforms.py
@@ -13,7 +13,7 @@ from cvxpy.constraints import ExpCone
 from cvxpy.constraints.constraint import Constraint
 from cvxpy.constraints.psd import PSD
 from cvxpy.expressions.constants import Constant
-from cvxpy.expressions.variable import upper_tri_to_full
+from cvxpy.atoms.affine.upper_tri import upper_tri_to_full
 from cvxpy.problems.objective import Objective
 from cvxpy.reductions.dcp2cone.cone_matrix_stuffing import ConeDims
 
@@ -153,7 +153,7 @@ def scale_psd_dual(cone_dims: ConeDims, lamb: cp.Variable) -> cp.Variable:
         offset = n - n_psd_entries - exp_offset
         for psd_dim in cone_dims.psd:
             # scale_vec has sqrt(2) on entries corresponding to off-diagonal entries, 1 otherwise
-            scale_vec = upper_tri_to_full(psd_dim).A.sum(axis=0) ** 0.5
+            scale_vec = upper_tri_to_full(psd_dim).toarray().sum(axis=0) ** 0.5
             compressed_vars = len(scale_vec)
             scaling_mat_diag[offset : offset + compressed_vars] = scale_vec
             offset += compressed_vars
@@ -330,7 +330,7 @@ def K_repr_bilin(
     C, d = affine_to_canon(Gy, local_to_glob, switched=False)
 
     if Fx.shape == ():
-        Fx = cp.reshape(Fx, (1,))
+        Fx = cp.reshape(Fx, (1,), order="F")
 
     return KRepresentation(f=C.T @ Fx, t=Fx.T @ d, constraints=[])
 
@@ -383,7 +383,7 @@ def add_cone_constraints(
     s: cp.Expression, cone_dims: ConeDims, dual: bool
 ) -> tuple[list[Constraint], cp.Variable]:
     assert len(s.shape) == 1 or s.shape[1] == 1, "s must be a vector"
-    s = cp.reshape(s, (s.shape[0],))
+    s = cp.reshape(s, (s.shape[0],), order="F")
 
     s_const = []
 
@@ -415,7 +415,7 @@ def add_cone_constraints(
 
             fill_coeff = Constant(upper_tri_to_full(psd_dim))
             flat_mat = fill_coeff @ z
-            full_mat = reshape(flat_mat, (psd_dim, psd_dim))
+            full_mat = reshape(flat_mat, (psd_dim, psd_dim), order="F")
             s_const.append(PSD(full_mat))
             offset += m
 

--- a/dsp/problem.py
+++ b/dsp/problem.py
@@ -20,6 +20,9 @@ from dsp.saddle_extremum import SaddleExtremum
 
 
 class MinimizeMaximize(Canonical):
+
+    NAME = "minimize-maximize"
+
     def __init__(self, expr: cp.Expression) -> None:
         self._validate_arguments(expr)
         self.args = [cp.Expression.cast_to_const(expr)]
@@ -37,6 +40,9 @@ class MinimizeMaximize(Canonical):
     @property
     def value(self) -> float:
         return self.expr.value
+
+    def __str__(self) -> str:
+        return ' '.join([self.NAME, self.args[0].name()])
 
 
 class SaddlePointProblem(cp.Problem):

--- a/dsp/saddle_extremum.py
+++ b/dsp/saddle_extremum.py
@@ -71,6 +71,9 @@ class SaddleExtremum(Atom):
     def concave_variables(self) -> list[cp.Variable]:
         raise NotImplementedError
 
+    def _grad(self, values):
+        return None
+
 
 class saddle_max(SaddleExtremum):
     r"""sup_{y\in Y}f(x,y)"""

--- a/dsp/saddle_extremum.py
+++ b/dsp/saddle_extremum.py
@@ -72,7 +72,9 @@ class SaddleExtremum(Atom):
         raise NotImplementedError
 
     def _grad(self, values):
-        return None
+        # This is an abstract method in the `Atom` superclass but appears unused in the dsp library. Dummy
+        # implementation here to prevent `TypeError: Can't instantiate abstract class...`
+        raise NotImplementedError
 
 
 class saddle_max(SaddleExtremum):

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -123,7 +123,7 @@ def test_epigraph_exp(y_val):
     p_bar = var_to_mat_mapping[t_primal.id]
     Q_bar = var_to_mat_mapping["eta"]
 
-    s_bar = s_bar.reshape(-1, 1)
+    s_bar = s_bar.reshape(-1, 1, order="F")
     u_temp = cp.Variable((Q_bar.shape[1], 1))
 
     Ax_b = s_bar - (R_bar * y + t_primal * p_bar + Q_bar @ u_temp)


### PR DESCRIPTION
Makes dsp compatible with cvxpy >= 1.6.0 and scipy >= 1.11.0. Feel free to ignore - I came across this library today and wanted to test it out and thought I might as well share my quick fixes. Noticed there's also a recent related [issue](https://github.com/cvxgrp/dsp/issues/29).

Changes:

1. Fix `upper_tri_to_full` import error ([moved](https://github.com/cvxpy/cvxpy/commit/94be35384bc62a2aa92b587136d7b71f8268fea4) in cvxpy)
2. Fix `.A` scipy attribute error ([deprecated since scipy 1.11.0](https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.sparse.csr_matrix.A.html))
3. Implement missing abstract methods for `MinimizeMaximize` and `SaddleExtremum`
5. Suppress cvxpy `.reshape` warning by adding `order="F"` kwarg

Tests are passing locally.